### PR TITLE
Ticket7

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -48,7 +48,7 @@ describe("GET /api/articles/:article_id", () => {
       .expect(200)
       .then((res) => {
         const { article } = res.body;
-        expect(article).toEqual({
+        expect(article).toMatchObject({
           article_id: 2,
           title: expect.any(String),
           topic: expect.any(String),
@@ -187,4 +187,26 @@ describe("GET /api/users", () => {
         });
     });
   });
+});
+describe("GET /api/articles/:article_id (comment count)", () => {
+  test("200: Responds with article specified by id, adding comment_count property that compiles the total count of comments linked to the specified article by article_id", () => {
+    const article_id = 5;
+    return request(app)
+      .get(`/api/articles/${article_id}`)
+      .expect(200)
+      .then((res) => {
+        const { article } = res.body;
+        expect(article).toEqual({
+          article_id: 5,
+          title: expect.any(String),
+          topic: expect.any(String),
+          author: expect.any(String),
+          body: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          comment_count: expect.any(String),
+        });
+      });
+  });
+  describe("Error handling", () => {});
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -69,15 +69,15 @@ describe("GET /api/articles/:article_id", () => {
           expect(res.body).toEqual({ message: "Article not found" });
         });
     });
-  });
-  test("400: Responds with Error when endpoint '/api/articles/:article_id' is not valid e.g. string instead of number for article_id", () => {
-    const article_id = "a";
-    return request(app)
-      .get(`/api/articles/${article_id}`)
-      .expect(400)
-      .then((res) => {
-        expect(res.body).toEqual({ message: "Bad Request" });
-      });
+    test("400: Responds with Error when endpoint '/api/articles/:article_id' is not valid e.g. string instead of number for article_id", () => {
+      const article_id = "a";
+      return request(app)
+        .get(`/api/articles/${article_id}`)
+        .expect(400)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "Bad Request" });
+        });
+    });
   });
 });
 
@@ -208,5 +208,24 @@ describe("GET /api/articles/:article_id (comment count)", () => {
         });
       });
   });
-  describe("Error handling", () => {});
+  describe("Error handling", () => {
+    test("404: Responds with 404 Error when endpoint is '/api/articles/:article_id' – a valid but non-existent", () => {
+      const article_id = 100;
+      return request(app)
+        .get(`/api/articles/${article_id}`)
+        .expect(404)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "Article not found" });
+        });
+    });
+    test("400: Responds with Error when endpoint '/api/articles/:article_id' is not valid e.g. string instead of number for article_id", () => {
+      const article_id = "a";
+      return request(app)
+        .get(`/api/articles/${article_id}`)
+        .expect(400)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "Bad Request" });
+        });
+    });
+  });
 });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,7 +2,10 @@ const db = require("../db/connection");
 
 exports.fetchArticleByID = (article_id) => {
   return db
-    .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .query(
+      `SELECT articles.article_id, articles.title, articles.topic, articles.author, articles.body, articles.created_at, articles.votes, COUNT(comments.article_id) AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id WHERE articles.article_id = $1 GROUP BY articles.article_id`,
+      [article_id]
+    )
     .then((article) => {
       if (article.rows.length === 0) {
         return Promise.reject({
@@ -14,6 +17,7 @@ exports.fetchArticleByID = (article_id) => {
       }
     });
 };
+//`SELECT * FROM articles WHERE article_id = $1`
 
 exports.updateVotesOfArticleByID = (articleId, newVote) => {
   return db


### PR DESCRIPTION
- Refactor fetchArticlesByID function in articles.models.js
- The fetchArticlesByID function now includes a new SQL query that will select the relevant columns and join the articles table with the comments table, retrieve count of comments for a specified article in the new comment_count column, LEFT JOIN if no comments and GROUP resulting rows by article id
- Add new tests for GET/api/articles/:articles_id (including 400 and 404 error handling)
- Pass the corresponding tests