### PR TITLE
Ticket11

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -296,7 +296,7 @@ describe("GET /api/articles", () => {
           expect(res.body).toEqual({ message: "Requested URL not found" });
         });
     });
-    test.skip("404: Responds with 404 error no content found if topic specified does not exist in database", () => {
+    test("404: Responds with 404 error no content found if topic specified does not exist in database", () => {
       return request(app)
         .get("/api/articles?topic=nonexistent")
         .expect(404)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -260,15 +260,6 @@ describe("GET /api/articles", () => {
         });
       });
   });
-  test("200: Responds with empty array of article objects when topic 'paper' is specified in query and it is valid, but no articles of that topic exists", () => {
-    return request(app)
-      .get("/api/articles?topic=paper")
-      .expect(200)
-      .then((res) => {
-        const { articles } = res.body;
-        expect(articles).toEqual([]);
-      });
-  });
   test("200: Responds with array of articles sorted by a non-default valid column, when article_id is specified as sort_by in query", () => {
     return request(app)
       .get("/api/articles?sort_by=article_id")
@@ -295,6 +286,23 @@ describe("GET /api/articles", () => {
         .then((res) => {
           expect(res.body).toEqual({ message: "Requested URL not found" });
         });
+    });
+    test("404: Responds with 404 error no content found when topic 'paper' is specified in query and it is valid, but no articles of that topic exists", () => {
+      return request(app)
+        .get("/api/articles?topic=paper")
+        .expect(404)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "No content found" });
+        });
+    });
+    test("404: Responds with 404 error no content found if topic specified is valid but does not exist in database", () => {
+      return request(app)
+        .get("/api/articles?topic=nonexistent")
+        .expect(404)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "No content found" });
+        });
+      s;
     });
     test("400: Responds with 400 error if sort_by specified is not valid", () => {
       return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -268,6 +268,15 @@ describe("GET /api/articles", () => {
         expect(articles).toBeSortedBy("article_id");
       });
   });
+  test("200: Responds with array of articles ordered by a non-default valid ORDER, when 'ASC' is specified as order in query", () => {
+    return request(app)
+      .get("/api/articles?order=ASC")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        expect(articles).toBeSorted("created_at", { descending: false });
+      });
+  });
   describe("Error handling for GET /api/articles", () => {
     test("404: Responds with 404 error when endpoint is GET/api/article (non-existent path)", () => {
       return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -296,12 +296,12 @@ describe("GET /api/articles", () => {
           expect(res.body).toEqual({ message: "Requested URL not found" });
         });
     });
-    test("404: Responds with 404 error no content found if topic specified does not exist in database", () => {
+    test("404: Responds with 404 error no topic found if topic specified does not exist in database", () => {
       return request(app)
         .get("/api/articles?topic=nonexistent")
         .expect(404)
         .then((res) => {
-          expect(res.body).toEqual({ message: "No content found" });
+          expect(res.body).toEqual({ message: "No topic found" });
         });
     });
     test("400: Responds with 400 error if sort_by specified is not valid", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -259,6 +259,15 @@ describe("GET /api/articles", () => {
         });
       });
   });
+  test("200: Responds with array of articles sorted by a non-default valid column, when article_id is specified as sort_by in query", () => {
+    return request(app)
+      .get("/api/articles?sort_by=article_id")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        expect(articles).toBeSortedBy("article_id");
+      });
+  });
   describe("Error handling for GET /api/articles", () => {
     test("404: Responds with 404 error when endpoint is GET/api/article (non-existent path)", () => {
       return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -296,6 +296,14 @@ describe("GET /api/articles", () => {
           expect(res.body).toEqual({ message: "Requested URL not found" });
         });
     });
+    test("400: Responds with 400 error if sort_by specified is not valid", () => {
+      return request(app)
+        .get("/api/articles?sort_by=invalid")
+        .expect(400)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "400 - Invalid Query" });
+        });
+    });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -240,7 +240,7 @@ describe("GET /api/articles", () => {
         expect(articles).toBeSorted("created_at", { descending: true });
       });
   });
-  test("200: Responds with an array of article objects filtered by topic passed in query", () => {
+  test("200: Responds with an array of article objects filtered by valid topic passed in query", () => {
     return request(app)
       .get("/api/articles?topic=cats")
       .expect(200)
@@ -260,7 +260,7 @@ describe("GET /api/articles", () => {
         });
       });
   });
-  test("200: Responds with an empty array when topic 'paper' is specified in query and it is valid, but no associated articles of that topic exists", () => {
+  test("200: Responds with an empty array when valid topic is specified in query, but no associated articles of that topic exists", () => {
     return request(app)
       .get("/api/articles?topic=paper")
       .expect(200)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -302,7 +302,6 @@ describe("GET /api/articles", () => {
         .then((res) => {
           expect(res.body).toEqual({ message: "No content found" });
         });
-      s;
     });
     test("400: Responds with 400 error if sort_by specified is not valid", () => {
       return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -304,6 +304,14 @@ describe("GET /api/articles", () => {
           expect(res.body).toEqual({ message: "400 - Invalid Query" });
         });
     });
+    test("400: Responds with 400 error if order specified is not valid", () => {
+      return request(app)
+        .get("/api/articles?order=invalid")
+        .expect(400)
+        .then((res) => {
+          expect(res.body).toEqual({ message: "400 - Invalid Query" });
+        });
+    });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -240,7 +240,7 @@ describe("GET /api/articles", () => {
         expect(articles).toBeSorted("created_at", { descending: true });
       });
   });
-  test("200: Responds with an array of article objects filtered by topic 'cats' when topic 'cats' is specified in query", () => {
+  test("200: Responds with an array of article objects filtered by topic passed in query", () => {
     return request(app)
       .get("/api/articles?topic=cats")
       .expect(200)
@@ -258,6 +258,15 @@ describe("GET /api/articles", () => {
             comment_count: expect.any(String),
           });
         });
+      });
+  });
+  test("200: Responds with an empty array when topic 'paper' is specified in query and it is valid, but no associated articles of that topic exists", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        expect(articles).toEqual([]);
       });
   });
   test("200: Responds with array of articles sorted by a non-default valid column, when article_id is specified as sort_by in query", () => {
@@ -287,15 +296,7 @@ describe("GET /api/articles", () => {
           expect(res.body).toEqual({ message: "Requested URL not found" });
         });
     });
-    test("404: Responds with 404 error no content found when topic 'paper' is specified in query and it is valid, but no articles of that topic exists", () => {
-      return request(app)
-        .get("/api/articles?topic=paper")
-        .expect(404)
-        .then((res) => {
-          expect(res.body).toEqual({ message: "No content found" });
-        });
-    });
-    test("404: Responds with 404 error no content found if topic specified is valid but does not exist in database", () => {
+    test.skip("404: Responds with 404 error no content found if topic specified does not exist in database", () => {
       return request(app)
         .get("/api/articles?topic=nonexistent")
         .expect(404)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -231,7 +231,7 @@ describe("GET /api/articles", () => {
         });
       });
   });
-  test("Responds with array of articles objects sorted by date in descending order by default", () => {
+  test("200: Responds with array of article objects sorted by date in descending order by default", () => {
     return request(app)
       .get("/api/articles")
       .expect(200)
@@ -240,7 +240,26 @@ describe("GET /api/articles", () => {
         expect(articles).toBeSorted("created_at", { descending: true });
       });
   });
-  describe("error handling", () => {
+  test("200: Responds with an array of article objects filtered by topic 'cats' when topic 'cats' is specified in query", () => {
+    return request(app)
+      .get("/api/articles?topic=cats")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        articles.forEach((article) => {
+          expect(article).toMatchObject({
+            article_id: expect.any(Number),
+            title: expect.any(String),
+            topic: "cats",
+            author: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            comment_count: expect.any(String),
+          });
+        });
+      });
+  });
+  describe("Error handling for GET /api/articles", () => {
     test("404: Responds with 404 error when endpoint is GET/api/article (non-existent path)", () => {
       return request(app)
         .get("/api/article")

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -246,6 +246,7 @@ describe("GET /api/articles", () => {
       .expect(200)
       .then((res) => {
         const { articles } = res.body;
+        expect(articles).toBeInstanceOf(Array);
         articles.forEach((article) => {
           expect(article).toMatchObject({
             article_id: expect.any(Number),
@@ -257,6 +258,15 @@ describe("GET /api/articles", () => {
             comment_count: expect.any(String),
           });
         });
+      });
+  });
+  test("200: Responds with empty array of article objects when topic 'paper' is specified in query and it is valid, but no articles of that topic exists", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        expect(articles).toEqual([]);
       });
   });
   test("200: Responds with array of articles sorted by a non-default valid column, when article_id is specified as sort_by in query", () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -29,7 +29,12 @@ exports.patchVotesOfArticleByID = (req, res, next) => {
 exports.getArticles = (req, res, next) => {
   const { sort_by } = req.query;
   const { order } = req.query;
-  fetchArticles(sort_by, order).then((articles) => {
-    res.status(200).send({ articles });
-  });
+  const { topic } = req.query;
+  fetchArticles(sort_by, order, topic)
+    .then((articles) => {
+      res.status(200).send({ articles });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -68,6 +68,8 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
     queryStr += ` ORDER BY ${sort_by}`;
     if ((validOrder.includes(order) && order === "asc") || order === "ASC") {
       queryStr += ` ASC`;
+    } else if (order && !validOrder.includes(order)) {
+      return Promise.reject({ status: 400, message: "400 - Invalid Query" });
     }
   } else {
     return Promise.reject({ status: 400, message: "400 - Invalid Query" });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -36,15 +36,25 @@ exports.updateVotesOfArticleByID = (articleId, newVote) => {
     });
 };
 
-exports.fetchArticles = (sort_by = "created_at", order = "DESC") => {
+exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   const validSortBy = ["created_at"];
   const validOrder = ["asc", "ASC", "desc", "DESC"];
+  const queryValues = [];
 
   let queryStr = `SELECT articles.article_id, articles.title, articles.topic, articles.author, articles.created_at, articles.votes, 
   COUNT(comments.article_id) AS comment_count 
   FROM articles 
   LEFT JOIN comments ON articles.article_id = comments.article_id 
   GROUP BY articles.article_id`;
+
+  if (topic) {
+    queryValues.push(topic);
+    queryStr = `SELECT articles.article_id, articles.title, articles.topic, articles.author, articles.created_at, articles.votes, 
+    COUNT(comments.article_id) AS comment_count 
+    FROM articles 
+    LEFT JOIN comments ON articles.article_id = comments.article_id WHERE articles.topic = $1
+    GROUP BY articles.article_id`;
+  }
 
   if (validSortBy.includes(sort_by)) {
     queryStr += ` ORDER BY ${sort_by}`;
@@ -55,7 +65,7 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC") => {
     Promise.reject({ status: 400, message: "400 - Invalid Query" });
   }
 
-  return db.query(queryStr).then((articles) => {
+  return db.query(queryStr, queryValues).then((articles) => {
     return articles.rows;
   });
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -59,8 +59,10 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
     queryStr += ` WHERE articles.topic = $1`;
   }
 
+  queryStr += ` GROUP BY articles.article_id`;
+
   if (validSortBy.includes(sort_by)) {
-    queryStr += ` GROUP BY articles.article_id ORDER BY ${sort_by}`;
+    queryStr += ` ORDER BY ${sort_by}`;
     if ((validOrder.includes(order) && order === "asc") || order === "ASC") {
       queryStr += ` ASC`;
     } else if (order && !validOrder.includes(order)) {
@@ -71,8 +73,6 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   }
 
   return db.query(queryStr, queryValues).then((articles) => {
-    if (!articles.rows.length) {
-      return Promise.reject({ status: 404, message: "No content found" });
-    } else return articles.rows;
+    return articles.rows;
   });
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -70,7 +70,7 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
       queryStr += ` ASC`;
     }
   } else {
-    Promise.reject({ status: 400, message: "400 - Invalid Query" });
+    return Promise.reject({ status: 400, message: "400 - Invalid Query" });
   }
 
   return db.query(queryStr, queryValues).then((articles) => {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -52,20 +52,15 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   let queryStr = `SELECT articles.article_id, articles.title, articles.topic, articles.author, articles.created_at, articles.votes, 
   COUNT(comments.article_id) AS comment_count 
   FROM articles 
-  LEFT JOIN comments ON articles.article_id = comments.article_id 
-  GROUP BY articles.article_id`;
+  LEFT JOIN comments ON articles.article_id = comments.article_id`;
 
   if (topic) {
     queryValues.push(topic);
-    queryStr = `SELECT articles.article_id, articles.title, articles.topic, articles.author, articles.created_at, articles.votes, 
-    COUNT(comments.article_id) AS comment_count 
-    FROM articles 
-    LEFT JOIN comments ON articles.article_id = comments.article_id WHERE articles.topic = $1
-    GROUP BY articles.article_id`;
+    queryStr += ` WHERE articles.topic = $1`;
   }
 
   if (validSortBy.includes(sort_by)) {
-    queryStr += ` ORDER BY ${sort_by}`;
+    queryStr += ` GROUP BY articles.article_id ORDER BY ${sort_by}`;
     if ((validOrder.includes(order) && order === "asc") || order === "ASC") {
       queryStr += ` ASC`;
     } else if (order && !validOrder.includes(order)) {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -80,7 +80,7 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
           if (!result.rows.length) {
             return Promise.reject({
               status: 404,
-              message: "No content found",
+              message: "No topic found",
             });
           } else return articles.rows;
         });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -67,7 +67,7 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   if (validSortBy.includes(sort_by)) {
     queryStr += ` ORDER BY ${sort_by}`;
     if ((validOrder.includes(order) && order === "asc") || order === "ASC") {
-      query += ` ASC`;
+      queryStr += ` ASC`;
     }
   } else {
     Promise.reject({ status: 400, message: "400 - Invalid Query" });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -37,7 +37,15 @@ exports.updateVotesOfArticleByID = (articleId, newVote) => {
 };
 
 exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
-  const validSortBy = ["created_at"];
+  const validSortBy = [
+    "created_at",
+    "article_id",
+    "title",
+    "topic",
+    "author",
+    "votes",
+    "comment_count",
+  ];
   const validOrder = ["asc", "ASC", "desc", "DESC"];
   const queryValues = [];
 

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -73,6 +73,17 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   }
 
   return db.query(queryStr, queryValues).then((articles) => {
-    return articles.rows;
+    if (!articles.rows.length) {
+      return db
+        .query(`SELECT * FROM topics WHERE slug = $1`, [topic])
+        .then((result) => {
+          if (!result.rows.length) {
+            return Promise.reject({
+              status: 404,
+              message: "No content found",
+            });
+          } else return articles.rows;
+        });
+    } else return articles.rows;
   });
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -76,6 +76,8 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   }
 
   return db.query(queryStr, queryValues).then((articles) => {
-    return articles.rows;
+    if (!articles.rows.length) {
+      return Promise.reject({ status: 404, message: "No content found" });
+    } else return articles.rows;
   });
 };


### PR DESCRIPTION
- add and pass tests for GET/api/articles when queries are passed in (specifying filter by topic, sort_by and order)
- refactor getArticles and fetchArticles to incorporate queries for filtering by topic, sort_by and order
- add error handling tests for 404 errors (Non existent topic and no articles of existing topic)
- add error handling tests for 400 errors (invalid sort_by and invalid order)